### PR TITLE
Use npm, if yarn is not installed

### DIFF
--- a/src/getInstallArgs.js
+++ b/src/getInstallArgs.js
@@ -1,0 +1,7 @@
+export default function getInstallArgs(cmd, packages) {
+  if (cmd === 'npm') {
+    return ['install', ...packages, '--save-dev'];
+  } else if (cmd === 'yarn') {
+    return ['add', ...packages, '--dev'];
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,8 @@ import {
 } from './utils';
 import * as Output from './output';
 import { concatAllArray } from 'jpjs';
+import getInstallCmd from './getInstallCmd';
+import getInstallArgs from './getInstallArgs';
 const pkg = require('../package.json');
 const createLogger = require('progress-estimator');
 // All configuration keys are optional, but it's recommended to specify a storage location.
@@ -179,7 +181,7 @@ prog
 
     const installSpinner = ora(Messages.installing(deps)).start();
     try {
-      await execa(`yarn`, ['add', ...deps, '--dev']);
+      await execa(getInstallArgs(getInstallCmd(), deps));
       installSpinner.succeed('Installed dependecines');
       console.log(Messages.start(pkg));
     } catch (error) {


### PR DESCRIPTION
If yarn is not install, this should fallback to npm.

Close #48 