### PR TITLE
build: remove "prepare" script

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,6 @@ prog
         scripts: {
           start: 'tsdx watch',
           build: 'tsdx build',
-          prepare: 'npm run build',
           test: 'tsdx test',
         },
         husky: {


### PR DESCRIPTION
The "prepare" script is executed not only when `yarn` is run, but also when any dependency is installed, so its more annoying than useful.