### PR TITLE
Create an entry file during watch cmd

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -250,10 +250,10 @@ prog
     opts.input = await getInputs(opts.entry, appPackageJson.source);
     const [cjsDev, cjsProd, ...otherConfigs] = createBuildConfigs(opts);
     if (opts.format.includes('cjs')) {
-      try {
-        await fs.writeFile(
-          resolveApp('dist/index.js'),
-          `
+      await util.promisify(mkdirp)(resolveApp('dist'));
+      await fs.writeFile(
+        resolveApp('dist/index.js'),
+        `
          'use strict'
 
       if (process.env.NODE_ENV === 'production') {
@@ -265,8 +265,7 @@ prog
           opts.name
         )}.cjs.development.js')
       }`
-        );
-      } catch (e) {}
+      );
     }
     const spinner = ora().start();
     await watch(

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,11 +257,11 @@ prog
          'use strict'
 
       if (process.env.NODE_ENV === 'production') {
-        module.exports = require('./${safeVariableName(
+        module.exports = require('./${safePackageName(
           opts.name
         )}.cjs.production.js')
       } else {
-        module.exports = require('./${safeVariableName(
+        module.exports = require('./${safePackageName(
           opts.name
         )}.cjs.development.js')
       }`


### PR DESCRIPTION
- Ensure that the CommonJS entry file is properly generated in `watch` cmd.
- Ensure that filenames match `build` cmd. Fixes #35