### PR TITLE
docs(readme): specify Jest v24 is used.  Clarify jsdom flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Examples
 
 ### `tsdx test`
 
-This runs Jest v23.x in watch mode. See [https://jestjs.io](https://jestjs.io) for options. If you are trying to test a React component, you likely want to pass in `--env=jsdom` just like you do in Create React App.
+This runs Jest v24.x in watch mode. See [https://jestjs.io](https://jestjs.io) for options. If you are using the React template, jest uses the flag `--env=jsdom` by default.
 
 ## Author
 

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -122,7 +122,7 @@ export function createRollupConfig(
           compress: {
             keep_infinity: true,
             pure_getters: true,
-            collapse_vars: false
+            collapse_vars: false,
           },
           ecma: 5,
           toplevel: format === 'es' || format === 'cjs',


### PR DESCRIPTION
This is using Jest v24 not v23.

From the create command:
```js
        scripts: {
          start: 'tsdx watch',
          build: 'tsdx build',
          test: template === 'react' ? 'tsdx test --env=jsdom' : 'tsdx test',
```
So it's wasn't necessary to say
> If you are trying to test a React component, you likely want to pass in `--env=jsdom` just like you do in Create React App

Proposed:
> If you are using the React template, jest uses the flag `--env=jsdom` by default.