### PR TITLE
Fix testMatch to find test files correctly

### DIFF
--- a/src/createJestConfig.ts
+++ b/src/createJestConfig.ts
@@ -9,7 +9,7 @@ export function createJestConfig(
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
     collectCoverageFrom: ['src/**/*.{ts,tsx}'],
-    testMatch: ['<rootDir>/test/**/?(*.)(spec|test).{ts,tsx}'],
+    testMatch: ['<rootDir>/test/**/*.+(spec|test).{ts,tsx}'],
     testURL: 'http://localhost',
     rootDir,
     watchPlugins: [

--- a/src/createJestConfig.ts
+++ b/src/createJestConfig.ts
@@ -9,7 +9,7 @@ export function createJestConfig(
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
     collectCoverageFrom: ['src/**/*.{ts,tsx}'],
-    testMatch: ['<rootDir>/test/**/*.+(spec|test).{ts,tsx}'],
+    testMatch: ['<rootDir>/test/**/*.(spec|test).{ts,tsx}'],
     testURL: 'http://localhost',
     rootDir,
     watchPlugins: [


### PR DESCRIPTION
The problem occured in #62 and seems to come from this part: `?(*.)`.
Applying the changes in this PR finds the files correctly and runs tests for `.ts` and `.tsx` files inside root and subfolders within `/test/`.

Can't check if this still works on other OS than Windows though. 

```
PS C:\dev\hidash> npm test

> hidash@0.1.0 test C:\dev\hidash
> tsdx test

 PASS  test/blah.test.ts
 PASS  test/fix/make.test.tsx

Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        3.362s
Ran all test suites.
```