### PR TITLE
Filter falsey values from build configs before passing them to rollup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ function createBuildConfigs(opts: any) {
       opts.format.includes('umd') &&
         createRollupConfig('umd', 'production', { ...opts, input }),
     ])
-  );
+  ).filter(Boolean);
 }
 
 async function moveTypes() {


### PR DESCRIPTION
Fixes https://github.com/palmerhq/tsdx/issues/76

I wasn't sure how to write a test for this. Sorry. I'd be happy to write a test if you point me to an example of a similar test that it should look like.

Details copied from commit message: 

> fix: remove falsey build configs
>
> If the `opts.format.includes` call above returns false, a `false` value
> is inserted into the array in place of a rollup config object. Each
> element of the `createBuildConfigs` is eventually passed into rollup
> as an `inputOption`. If one of these elements is `false`, the script will
> pass that value as a config to rollup which results in a rollup error
> stating: "You must supply an options object to rollup"
>
> This commit fixes that issue by filtering out falsey values.