### PR TITLE
Budget 1 char for +/- from diffs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ prog
           },
         },
         prettier: {
-          printWidth: 80,
+          printWidth: 79,
           semi: true,
           singleQuote: true,
           trailingComma: 'es5',


### PR DESCRIPTION
When looking at git diffs on 80char terminals it's helpful to have lines not
break when they are exactly 80 chars and are prepended with a + or -.