### PR TITLE
fix external module detection on Windows

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ export const safePackageName = (name: string) =>
   name.toLowerCase().replace(/((^[^a-zA-Z]+)|[^\w.-])|([^a-zA-Z0-9]+$)/g, '');
 
 export const external = (id: string) =>
-  !id.startsWith('.') && !id.startsWith('/');
+  !id.startsWith('.') && !path.isAbsolute(id);
 
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebookincubator/create-react-app/issues/637

--- a/test/fixtures/build-default/src/foo.ts
+++ b/test/fixtures/build-default/src/foo.ts
@@ -1,0 +1,1 @@
+export const foo = () => 'bar';

--- a/test/fixtures/build-default/src/index.ts
+++ b/test/fixtures/build-default/src/index.ts
@@ -1,3 +1,5 @@
+export { foo } from './foo';
+
 export const sum = (a: number, b: number) => {
   if ('development' === process.env.NODE_ENV) {
     console.log('fuck');

--- a/test/tests/tsdx-build.test.js
+++ b/test/tests/tsdx-build.test.js
@@ -42,6 +42,15 @@ describe('tsdx build', () => {
     expect(output.code).toBe(0);
   });
 
+  it('should create the library correctly', () => {
+    util.setupStageWithFixture(stageName, 'build-default');
+
+    shell.exec('node ../dist/index.js build');
+
+    const lib = require(`../../${stageName}/dist`);
+    expect(lib.foo()).toBe('bar');
+  });
+
   afterEach(() => {
     util.teardownStage(stageName);
   });


### PR DESCRIPTION
Fixes #87 

Absolute path detection was not working for Windows users. I updated the util to use Node's built-in function.

I also created a regression test in the testing suite to ensure that exports defined in other files are correctly included in the final library build.