### PR TITLE
Explicitly specify ts and tsx extensions in babel options

### DIFF
--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_EXTENSIONS } from '@babel/core';
 import { safeVariableName, safePackageName, external } from './utils';
 import { paths } from './constants';
 import { terser } from 'rollup-plugin-terser';
@@ -14,6 +15,7 @@ const replacements = [{ original: 'lodash', replacement: 'lodash-es' }];
 
 const babelOptions = {
   exclude: /node_modules/,
+  extensions: [...DEFAULT_EXTENSIONS, 'ts', 'tsx'],
   plugins: [
     'annotate-pure-calls',
     'dev-expression',

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -5,6 +5,13 @@ declare module 'ora';
 declare module 'sade';
 declare module 'tiny-glob/sync';
 declare module 'ansi-escapes';
+
+// Patch Babel
+// @see line 226 of https://unpkg.com/@babel/core@7.4.4/lib/index.js
+declare module '@babel/core' {
+  export const DEFAULT_EXTENSIONS: string[];
+}
+
 // Rollup plugins
 declare module '@jaredpalmer/rollup-plugin-preserve-shebang';
 declare module 'rollup-plugin-babel';


### PR DESCRIPTION
Fixes https://github.com/palmerhq/tsdx/issues/95

>rollup-plugin-typescript2 transpiles the code but doesn't change the
file extensions. Files with ts and tsx extentions aren't processed by
Babel by default so we need to add those extensions to the babel config.

I'm not actually using tsdx on a production app (yet? we need to be able to configure babel though 😕) so I don't have a great way to test this with confidence for a real world project. 

Also I'm seeing...
> Module '"../../../../../../Users/jake/Code/jakegavin/tsdx/node_modules/@types/babel__core"' has no exported member 'DEFAULT_EXTENSIONS'

But its [there](https://github.com/babel/babel/blob/1969e6b6aa7d90be3fbb3aca98ea96849656a55a/packages/babel-core/src/index.js#L39-L45). I guess it's maybe not in the [babel core types](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/babel__core). I have a PR up to add it: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/35336