### PR TITLE
Remove Typescript "esnext" target override from rollup config.

### DIFF
--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -97,11 +97,7 @@ export function createRollupConfig(
             sourceMap: true,
             declaration: true,
             jsx: 'react',
-          },
-        },
-        tsconfigOverride: {
-          compilerOptions: {
-            target: 'esnext',
+            target: 'es5',
           },
         },
       }),


### PR DESCRIPTION
Fixes https://github.com/palmerhq/tsdx/issues/101

The config for the typescript rollup plugin had an `esnext` override for the `target`, so files weren't getting compiled down.  Set a default to `es5` that can be overridden by the `tsconfig` at the project level.