### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+yarn-error.log


### PR DESCRIPTION
This does not resolve #105 but could prevent `yarn-error.log` get added in accidentally in future