### PR TITLE
Fix React template .gitignore

### DIFF
--- a/templates/react/gitignore
+++ b/templates/react/gitignore
@@ -1,6 +1,7 @@
 *.log
 .DS_Store
 node_modules
+.cache
 .rts2_cache_cjs
 .rts2_cache_es
 .rts2_cache_umd


### PR DESCRIPTION
The React template has a `.gitignore` file at the root of the project and an additional `.gitignore` in the `/example` playground directory.

Locally, the `/example/.gitignore` file was ignored, causing the `/example/.cache` directory to be committed. 

This PR adds `.cache` to the root `.gitignore` file to avoid this problem.