### PR TITLE
feat(custom-tsconfig): Add ability to specify custom tsconfig.json

### DIFF
--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -54,7 +54,12 @@ let shebang: any = {};
 export function createRollupConfig(
   format: 'cjs' | 'umd' | 'es',
   env: 'development' | 'production',
-  opts: { input: string; name: string; target: 'node' | 'browser' }
+  opts: {
+    input: string;
+    name: string;
+    target: 'node' | 'browser';
+    tsconfig?: string;
+  }
 ) {
   return {
     // Tell Rollup the entry point to the package
@@ -141,6 +146,7 @@ export function createRollupConfig(
       typescript({
         typescript: require('typescript'),
         cacheRoot: `./.rts2_cache_${format}`,
+        tsconfig: opts.tsconfig,
         tsconfigDefaults: {
           compilerOptions: {
             sourceMap: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,6 +247,8 @@ prog
   .example('watch --name Foo')
   .option('--format', 'Specify module format(s)', 'cjs,es,umd')
   .example('watch --format cjs,es')
+  .option('--tsconfig', 'Specify custom tsconfig path')
+  .example('build --tsconfig ./tsconfig.foo.json')
   .action(async (opts: any) => {
     opts.name = opts.name || appPackageJson.name;
     opts.input = await getInputs(opts.entry, appPackageJson.source);
@@ -315,6 +317,8 @@ prog
   .example('build --name Foo')
   .option('--format', 'Specify module format(s)', 'cjs,es,umd')
   .example('build --format cjs,es')
+  .option('--tsconfig', 'Specify custom tsconfig path')
+  .example('build --tsconfig ./tsconfig.foo.json')
   .action(async (opts: any) => {
     opts.name = opts.name || appPackageJson.name;
     opts.input = await getInputs(opts.entry, appPackageJson.source);


### PR DESCRIPTION
It seems working for `build` and `watch` commands. I will need help for `test`.

example commands with `tsconfig` flag

`tsdx build --tsconfig ./tsconfig.foo.json`
`tsdx watch --tsconfig ./tsconfig.foo.json`

