### PR TITLE
Fix: Broken build with `tsdx build --format es`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -353,7 +353,6 @@ prog
         .map(
           [cjsDev, cjsProd, ...otherConfigs],
           async (inputOptions: RollupOptions & { output: OutputOptions }) => {
-            console.log(inputOptions);
             let bundle = await rollup(inputOptions);
             await bundle.write(inputOptions.output);
             await moveTypes();

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,8 @@ function createBuildConfigs(opts: any) {
       opts.format.includes('cjs') &&
         createRollupConfig('cjs', 'production', { ...opts, input }),
       opts.format.includes('es') &&
+        createRollupConfig('es', 'development', { ...opts, input }),
+      opts.format.includes('es') &&
         createRollupConfig('es', 'production', { ...opts, input }),
       opts.format.includes('umd') &&
         createRollupConfig('umd', 'development', { ...opts, input }),
@@ -351,6 +353,7 @@ prog
         .map(
           [cjsDev, cjsProd, ...otherConfigs],
           async (inputOptions: RollupOptions & { output: OutputOptions }) => {
+            console.log(inputOptions);
             let bundle = await rollup(inputOptions);
             await bundle.write(inputOptions.output);
             await moveTypes();


### PR DESCRIPTION
I have added `development` build for `es` format and it fixed the bug #114 