### PR TITLE
Remove UMD format from default build outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Despite all the recent hype, setting up a new TypeScript (x React) library can b
 
 TSDX comes with the "battery-pack included" and is part of a complete TypeScript breakfast:
 
-- Bundles your code with [Rollup](https://github.com/rollup/rollup) and outputs multiple module formats (CJS, UMD & ESM) plus development and production builds
+- Bundles your code with [Rollup](https://github.com/rollup/rollup) and outputs multiple module formats (CJS & ESM by default, and also UMD if you want) plus development and production builds
 - Comes with treeshaking, ready-to-rock lodash optimizations, and minification/compression
 - Live reload / watch-mode
 - Works with React
@@ -97,7 +97,7 @@ export const sum = (a: number, b: number) => {
 };
 ```
 
-`tsdx build` will output an ES module file, 2 UMD files (dev and prod), and 3 CommonJS files (dev, prod, and an entry file). For brevity, let's examine the CommonJS output (comments added for emphasis):
+`tsdx build` will output an ES module file and 3 CommonJS files (dev, prod, and an entry file). If you want to specify a UMD build, you can do that as well. For brevity, let's examine the CommonJS output (comments added for emphasis):
 
 ```js
 // Entry File
@@ -279,14 +279,14 @@ Options
   -i, --entry    Entry module(s)
   --target       Specify your target environment  (default web)
   --name         Specify name exposed in UMD builds
-  --format       Specify module format(s)  (default cjs,es,umd)
+  --format       Specify module format(s)  (default cjs,es)
   -h, --help     Displays this message
 
 Examples
   $ tsdx watch --entry src/foo.tsx
   $ tsdx watch --target node
   $ tsdx watch --name Foo
-  $ tsdx watch --format cjs,es
+  $ tsdx watch --format cjs,es,umd
 ```
 
 ### `tsdx build`
@@ -302,14 +302,14 @@ Options
   -i, --entry    Entry module(s)
   --target       Specify your target environment  (default web)
   --name         Specify name exposed in UMD builds
-  --format       Specify module format(s)  (default cjs,es,umd)
+  --format       Specify module format(s)  (default cjs,es)
   -h, --help     Displays this message
 
 Examples
   $ tsdx build --entry src/foo.tsx
   $ tsdx build --target node
   $ tsdx build --name Foo
-  $ tsdx build --format cjs,es
+  $ tsdx build --format cjs,es,umd
 ```
 
 ### `tsdx test`

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,6 @@ prog
         name: safeName,
         version: '0.1.0',
         main: 'dist/index.js',
-        'umd:main': `dist/${safeName}.umd.production.js`,
         module: `dist/${safeName}.es.production.js`,
         typings: 'dist/index.d.ts',
         files: ['dist'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -313,7 +313,7 @@ prog
   .example('build --target node')
   .option('--name', 'Specify name exposed in UMD builds')
   .example('build --name Foo')
-  .option('--format', 'Specify module format(s)', 'cjs,es,umd')
+  .option('--format', 'Specify module format(s)', 'cjs,es')
   .example('build --format cjs,es')
   .action(async (opts: any) => {
     opts.name = opts.name || appPackageJson.name;

--- a/test/tests/tsdx-build.test.js
+++ b/test/tests/tsdx-build.test.js
@@ -30,12 +30,6 @@ describe('tsdx build', () => {
     expect(
       shell.test('-f', 'dist/build-default.es.production.js')
     ).toBeTruthy();
-    expect(
-      shell.test('-f', 'dist/build-default.umd.development.js')
-    ).toBeTruthy();
-    expect(
-      shell.test('-f', 'dist/build-default.umd.development.js')
-    ).toBeTruthy();
 
     expect(shell.test('-f', 'dist/index.d.ts')).toBeTruthy();
 


### PR DESCRIPTION
With this pr `tsdx build` command no longer build `umd` format as default. But still `tsdx build --format umd` can be used for umd builds. #120 

I have deleted `umd` output related tests. Should we add test cases for different format combinations?