### PR TITLE
Don't depend on specific TS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "sade": "^1.4.2",
     "tiny-glob": "^0.2.6",
     "ts-jest": "^24.0.2",
-    "tslib": "^1.9.3",
+    "tslib": "^1.9.3"
   },
   "devDependencies": {
     "@types/ansi-escapes": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "tiny-glob": "^0.2.6",
     "ts-jest": "^24.0.2",
     "tslib": "^1.9.3",
-    "typescript": "^3.4.5"
   },
   "devDependencies": {
     "@types/ansi-escapes": "^4.0.0",
@@ -87,7 +86,11 @@
     "tslint": "^5.16.0",
     "tslint-config-palmerhq": "^1.0.2",
     "tslint-config-prettier": "^1.18.0",
-    "tslint-react": "^4.0.0"
+    "tslint-react": "^4.0.0",
+    "typescript": "^3.4.5"
+  },
+  "peerDependencies": {
+    "typescript": "3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
I've run into the issue where I have TS 3.2 in the workspace where I want to use TSDX compiled module. However, TSDX got installed with 3.5.2 and compiles with that version. There are some breaking changes between those versions.

I could surely use Yarn resolutions to overcome that, but that's hardly a scalable solution. So I propose this change to let the user decide on the TS version.