### PR TITLE
fixed issue mentioned in #148 - Gitignore contains '.rts2_cache_esm'

### DIFF
--- a/templates/basic/gitignore
+++ b/templates/basic/gitignore
@@ -2,6 +2,6 @@
 .DS_Store
 node_modules
 .rts2_cache_cjs
-.rts2_cache_es
+.rts2_cache_esm
 .rts2_cache_umd
 dist

--- a/templates/react/gitignore
+++ b/templates/react/gitignore
@@ -3,6 +3,6 @@
 node_modules
 .cache
 .rts2_cache_cjs
-.rts2_cache_es
+.rts2_cache_esm
 .rts2_cache_umd
 dist


### PR DESCRIPTION
This is the issue mentioned in #148.

Tested with `yarn link` mentioned in [contribution guideline ](https://github.com/dance2die/tsdx/blob/master/CONTRIBUTING.md).

![nMu0GZ5391](https://user-images.githubusercontent.com/8465237/59730195-6baa5300-920f-11e9-83a5-234834d039a6.gif)


You can see that adding the tsdx created project to a git repo doesn't stage the "*.esm" folder.
![sUqk4iuu8Y](https://user-images.githubusercontent.com/8465237/59730272-be840a80-920f-11e9-9ff3-53afa1cee02a.gif)
