### PR TITLE
Update React template with ESM and type

### DIFF
--- a/templates/react/src/index.tsx
+++ b/templates/react/src/index.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 
 // Delete me
-export const Thing = () => {
+export const Thing: React.FC = () => {
   return <div>the snozzberries taste like snozzberries</div>;
 };


### PR DESCRIPTION
Hey, thanks for this project, really great work!

Because we have `compilerOptions.esModuleInterop` set to true in `tsconfig.json`, we can add the normal ES Modules syntax for importing React, or am I missing something? 

And we can use the `React.FC` type for the dummy component.