### PR TITLE
Provide ability to preserve console output during watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,12 +278,13 @@ Usage
   $ tsdx watch [options]
 
 Options
-  -i, --entry    Entry module(s)
-  --target       Specify your target environment  (default web)
-  --name         Specify name exposed in UMD builds
-  --format       Specify module format(s)  (default cjs,esm)
-  --tsconfig     Specify your custom tsconfig path (default <root-folder>/tsconfig.json)
-  -h, --help     Displays this message
+  -i, --entry           Entry module(s)
+  --target              Specify your target environment  (default web)
+  --name                Specify name exposed in UMD builds
+  --format              Specify module format(s)  (default cjs,esm)
+  --tsconfig            Specify your custom tsconfig path (default <root-folder>/tsconfig.json)
+  --preserveWatchOutput Keep outdated console output in watch mode instead of clearing the screen
+  -h, --help            Displays this message
 
 Examples
   $ tsdx watch --entry src/foo.tsx

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Options
   --name                Specify name exposed in UMD builds
   --format              Specify module format(s)  (default cjs,esm)
   --tsconfig            Specify your custom tsconfig path (default <root-folder>/tsconfig.json)
-  --preserveWatchOutput Keep outdated console output in watch mode instead of clearing the screen
+  --verbose             Keep outdated console output in watch mode instead of clearing the screen
   -h, --help            Displays this message
 
 Examples

--- a/src/index.ts
+++ b/src/index.ts
@@ -261,6 +261,11 @@ prog
   .example('watch --name Foo')
   .option('--format', 'Specify module format(s)', 'cjs,esm')
   .example('watch --format cjs,esm')
+  .option(
+    '--preserveWatchOutput',
+    'Keep outdated console output in watch mode instead of clearing the screen'
+  )
+  .example('watch --preserveWatchOutput')
   .option('--tsconfig', 'Specify custom tsconfig path')
   .example('build --tsconfig ./tsconfig.foo.json')
   .action(async (dirtyOpts: any) => {
@@ -282,7 +287,9 @@ prog
       }))
     ).on('event', async event => {
       if (event.code === 'START') {
-        clearConsole();
+        if (!opts.preserveWatchOutput) {
+          clearConsole();
+        }
         spinner.start(chalk.bold.cyan('Compiling modules...'));
       }
       if (event.code === 'ERROR') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,10 +262,10 @@ prog
   .option('--format', 'Specify module format(s)', 'cjs,esm')
   .example('watch --format cjs,esm')
   .option(
-    '--preserveWatchOutput',
+    '--verbose',
     'Keep outdated console output in watch mode instead of clearing the screen'
   )
-  .example('watch --preserveWatchOutput')
+  .example('watch --verbose')
   .option('--tsconfig', 'Specify custom tsconfig path')
   .example('build --tsconfig ./tsconfig.foo.json')
   .action(async (dirtyOpts: any) => {
@@ -287,7 +287,7 @@ prog
       }))
     ).on('event', async event => {
       if (event.code === 'START') {
-        if (!opts.preserveWatchOutput) {
+        if (!opts.verbose) {
           clearConsole();
         }
         spinner.start(chalk.bold.cyan('Compiling modules...'));


### PR DESCRIPTION
Hey there!

Huge fan of `tsdx`, we currently use it to compile packages within our monorepo.

When running tsdx in watch mode, tsdx currently clears the console with no ability to retain the console output. This PR adds an opt-in ability to preserve the console output during watch. This PR behavior aligns with the existing TypeScript compiler option ( https://www.typescriptlang.org/docs/handbook/compiler-options.html, e.g. `tsc -w --preserveWatchOutput`).

As far as use cases, a common workflow inside a monorepo is to run all packages in watch mode using something like [`wsrun`](https://github.com/hfour/wsrun). Clearing the output makes it hard to debug or audit the logs if something goes wrong within the monorepo dependency chain on start up.