### PR TITLE
Update createJestConfig.ts `testMatch` to allow for other folder structures

### DIFF
--- a/src/createJestConfig.ts
+++ b/src/createJestConfig.ts
@@ -12,7 +12,7 @@ export function createJestConfig(
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
     collectCoverageFrom: ['src/**/*.{ts,tsx}'],
-    testMatch: ['<rootDir>/test/**/*.(spec|test).{ts,tsx}'],
+    testMatch: ['<rootDir>/**/*.(spec|test).{ts,tsx}'],
     testURL: 'http://localhost',
     rootDir,
     watchPlugins: [


### PR DESCRIPTION
I like to pair testing files with my source code files so everything is collocated in a file explorer. This shouldn't be a breaking change and will simply allow me to create test files outside of the initially created `test` folder.