### PR TITLE
Gracefully exit with code 1 when build failed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -340,8 +340,10 @@ prog
           throw e;
         });
       logger(promise, 'Building modules');
+      await promise;
     } catch (error) {
       logError(error);
+      process.exit(1);
     }
   });
 

--- a/test/fixtures/build-invalid/package.json
+++ b/test/fixtures/build-invalid/package.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "build": "tsdx build"
+  },
+  "name": "build-invalid",
+  "license": "MIT"
+}

--- a/test/fixtures/build-invalid/src/index.ts
+++ b/test/fixtures/build-invalid/src/index.ts
@@ -1,0 +1,1 @@
+export const inconsistentType: number = '123';

--- a/test/fixtures/build-invalid/tsconfig.json
+++ b/test/fixtures/build-invalid/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "ESNext",
+    "lib": ["dom", "esnext"],
+    "declaration": true,
+    "sourceMap": true,
+    "rootDir": "./",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "paths": {
+      "*": ["src/*", "node_modules/*"]
+    },
+    "jsx": "react",
+    "esModuleInterop": true
+  },
+  "include": ["src", "types"]
+}

--- a/test/tests/tsdx-build.test.js
+++ b/test/tests/tsdx-build.test.js
@@ -43,6 +43,12 @@ describe('tsdx build', () => {
     expect(lib.foo()).toBe('bar');
   });
 
+  it('should fail gracefully with exit code 1 when build failed', () => {
+    util.setupStageWithFixture(stageName, 'build-invalid');
+    const code = shell.exec('node ../dist/index.js build').code;
+    expect(code).toBe(1);
+  });
+
   afterEach(() => {
     util.teardownStage(stageName);
   });


### PR DESCRIPTION
I found some problems with `build` command.

1. It does exit with code `0` even when the build failed. I think it should be `1`.
2. When it fails, the error won't be caught and that causes `UnhandledPromiseRejectionWarning`.