### PR TITLE
Exit different than 0 when build is failing.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -331,9 +331,13 @@ prog
         .map(
           buildConfigs,
           async (inputOptions: RollupOptions & { output: OutputOptions }) => {
-            let bundle = await rollup(inputOptions);
+          try {
+            let bundle = await rollup_1.rollup(inputOptions);
             await bundle.write(inputOptions.output);
             await moveTypes();
+          } catch (e) {
+            console.error(e);
+            process.exit(1);
           }
         )
         .catch((e: any) => {


### PR DESCRIPTION
I noticed that our CI pipeline could not catch build errors due to that they aren't exitting the process with an error code.