### PR TITLE
Add ability to define custom variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "babel-plugin-macros": "^2.6.1",
     "babel-plugin-transform-async-to-promises": "^0.8.14",
     "babel-plugin-transform-rename-import": "^2.3.0",
+    "babel-plugin-transform-replace-expressions": "^0.2.0",
     "babel-traverse": "^6.26.0",
     "babylon": "^6.18.0",
     "camelcase": "^5.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,8 +316,10 @@ prog
   .example('watch --verbose')
   .option('--tsconfig', 'Specify custom tsconfig path')
   .example('watch --tsconfig ./tsconfig.foo.json')
-  .option('--extractErrors', 'Extract invariant errors to ./errors/codes.json.')
-  .example('build --extractErrors')
+  .option('--extractErrors', 'Extract invariant errors to ./errors/codes.json')
+  .example('watch --extractErrors')
+  .option('--define', 'Replace constants with hard-coded values')
+  .example('watch --define A=1,ZOOP=FOO')
   .action(async (dirtyOpts: any) => {
     const opts = await normalizeOpts(dirtyOpts);
     const buildConfigs = createBuildConfigs(opts);
@@ -375,13 +377,10 @@ prog
   .example('build --format cjs,esm')
   .option('--tsconfig', 'Specify custom tsconfig path')
   .example('build --tsconfig ./tsconfig.foo.json')
-  .option(
-    '--extractErrors',
-    'Extract errors to ./errors/codes.json and provide a url for decoding.'
-  )
-  .example(
-    'build --extractErrors=https://reactjs.org/docs/error-decoder.html?invariant='
-  )
+  .option('--extractErrors', 'Extract errors to ./errors/codes.json')
+  .example('build --extractErrors')
+  .option('--define', 'Replace constants with hard-coded values')
+  .example('build --define A=1,ZOOP=FOO')
   .action(async (dirtyOpts: any) => {
     const opts = await normalizeOpts(dirtyOpts);
     const buildConfigs = createBuildConfigs(opts);

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,4 +17,6 @@ export interface TsdxOptions {
   minify?: boolean;
   // Is this the very first rollup config (and thus should one-off metadata be extracted)?
   writeMeta?: boolean;
+  // Define key values to be replaced (e.g. --define A=1)
+  define?: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,3 +35,44 @@ export function clearConsole() {
     process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H'
   );
 }
+
+// Convert booleans and int define= values to literals.
+// This is more intuitive than `microbundle --define A=1` producing A="1".
+export const toReplacementExpression = (value: string, name: string) => {
+  // --define A="1",B='true' produces string:
+  const matches = value.match(/^(['"])(.+)\1$/);
+  if (matches) {
+    return [JSON.stringify(matches[2]), name];
+  }
+
+  // --define A=1,B=true produces int/boolean literal:
+  if (/^(true|false|\d+)$/i.test(value)) {
+    return [value, name];
+  }
+
+  // default: string literal
+  return [JSON.stringify(value), name];
+};
+
+// Parses values of the form "$=jQuery,React=react" into key-value object pairs.
+export const parseMappingArgument = (
+  globalStrings: string,
+  processValue: (value: string, name: string) => any
+) => {
+  const globals: any = {};
+  globalStrings.split(',').forEach(globalString => {
+    let [key, value] = globalString.split('=');
+    if (processValue) {
+      const r = processValue(value, key);
+      if (r !== undefined) {
+        if (Array.isArray(r)) {
+          [value, key] = r;
+        } else {
+          value = r;
+        }
+      }
+    }
+    globals[key] = value;
+  });
+  return globals;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,7 +253,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.3.tgz#32f5df65744b70888d17872ec106b02434ba1489"
   integrity sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA==
 
-"@babel/parser@^7.4.5", "@babel/parser@^7.5.5":
+"@babel/parser@^7.3.3", "@babel/parser@^7.4.5", "@babel/parser@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
   integrity sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==
@@ -1688,6 +1688,13 @@ babel-plugin-transform-rename-import@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-rename-import/-/babel-plugin-transform-rename-import-2.3.0.tgz#5d9d645f937b0ca5c26a24b2510a06277b6ffd9b"
   integrity sha512-dPgJoT57XC0PqSnLgl2FwNvxFrWlspatX2dkk7yjKQj5HHGw071vAcOf+hqW8ClqcBDMvEbm6mevn5yHAD8mlQ==
+
+babel-plugin-transform-replace-expressions@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-replace-expressions/-/babel-plugin-transform-replace-expressions-0.2.0.tgz#59cba8df4b4a675e7c78cd21548f8e7685bbc30d"
+  integrity sha512-Eh1rRd9hWEYgkgoA3D0kGp7xJ/wgVshgsqmq60iC4HVWD+Lux+fNHSHBa2v1Hsv+dHflShC71qKhiH40OiPtDA==
+  dependencies:
+    "@babel/parser" "^7.3.3"
 
 babel-preset-jest@^24.6.0:
   version "24.6.0"


### PR DESCRIPTION
Add `--define` flag for defining custom variables that will be replaced at build-time. It uses `babel-plugin-transform-replace-expressions` under the hood. to replace expressions with values in noth your source code (in `src`) and in your `node_modules` as well. Other babel transforms are NOT executed on `node_modules` at this time, just this special replace-expression plugin.

## Usage

Pass a comma-separated list of key-values to the `--define` flag in your `package.json`. You do not need to add quotes for strings values. Numbers WILL be cast to numbers automagically.

```bash
tsdx --build --define FOO=hello # => FOO = "hello"
tsdx --build --define FOO=hello,VERSION=2 # => FOO = "hello", VERSION = 2
```
> It works the same way for `tsdx watch --define`

### Example
We want to define `ZOOP` as "foo" and `VERSION` as `2` to in our package.


First, to get TypeScript to play nicely, you should add a `./src/env.d.ts` file with variable declarations.
```tsx
// ./src/env.d.ts
declare var ZOOP: string;
declare var VERSION: number;
```
Now we can use these like they were magically equivalent to whatever we set them to. Since these are treated as values by TypeScript, you do not need to import them. 
```tsx
// src/index.ts
export function sup() {
  console.log(VERSION)
  console.log(ZOOP)
}
```
In our package.json, we use the `--define` flag
```json
// package.json
"scripts": {
   "start": "tsdx watch --define ZOOP=foo,VERSION=2",
   "build": "tsdx build --define ZOOP=foo,VERSION=2"
}
```
When we run `yarn build` or `yarn start`, TSDX will do the replacements and our output will look like this... (note: only including CJS outputs for brevity, replacements are made in all module formats).
```js
// dist/mylib.cjs.development.js
'use strict';

function sup() {
  console.log(2);
  console.log("foo");
}

exports.sup = sup;
//# sourceMappingURL=mylib.cjs.development.js.map
```
```js
// dist/mylib.cjs.production.js
"use strict";exports.sup=function(){console.log(2);console.log("foo")};
//# sourceMappingURL=mylib.cjs.production.min.js.map	
```

## Future Work / Discussion
- Ability to define different values for dev/prod?

