### PR TITLE
Fix lint command by allowing use --write-file flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -493,7 +493,7 @@ prog
       'write-file': boolean;
       _: string[];
     }) => {
-      if (opts['_'].length === 0) {
+      if (opts['_'].length === 0 && !opts['write-file']) {
         prog.help('lint');
         console.log(chalk.red('No input files specified.'));
         process.exit(1);

--- a/test/tests/lint/tsdx-lint.test.js
+++ b/test/tests/lint/tsdx-lint.test.js
@@ -4,8 +4,11 @@
 'use strict';
 
 const shell = require('shelljs');
+const util = require('../../fixtures/util');
 
 shell.config.silent = true;
+
+const stageName = 'stage-build';
 
 describe('tsdx lint', () => {
   it('should fail to lint a ts file with errors', () => {
@@ -39,5 +42,24 @@ describe('tsdx lint', () => {
     const testFile = 'test/tests/lint/react-file-without-lint-error.tsx';
     const output = shell.exec(`node dist/index.js lint ${testFile}`);
     expect(output.code).toBe(0);
+  });
+
+  it('should not lint', () => {
+    const output = shell.exec(`node dist/index.js lint`);
+    expect(output.code).toBe(1);
+    expect(output.toString()).toContain('No input files specified.');
+  });
+
+  describe('when --write-file is used', () => {
+    beforeEach(() => {
+      util.teardownStage(stageName);
+      util.setupStageWithFixture(stageName, 'build-default');
+    });
+
+    it('should create the field', () => {
+      const output = shell.exec(`node ../dist/index.js lint --write-file`);
+      expect(shell.test('-f', '.eslintrc.js')).toBeTruthy();
+      expect(output.code).toBe(0);
+    });
   });
 });

--- a/test/tests/lint/tsdx-lint.test.js
+++ b/test/tests/lint/tsdx-lint.test.js
@@ -56,7 +56,7 @@ describe('tsdx lint', () => {
       util.setupStageWithFixture(stageName, 'build-default');
     });
 
-    it('should create the field', () => {
+    it('should create the file', () => {
       const output = shell.exec(`node ../dist/index.js lint --write-file`);
       expect(shell.test('-f', '.eslintrc.js')).toBeTruthy();
       expect(output.code).toBe(0);


### PR DESCRIPTION
Currently if you try `tsdx lint --write-file` you get:

```sh
  Description
    Run eslint with Prettier

  Usage
    $ tsdx lint [options]

  Options
    --fix               Fixes fixable errors and warnings
    --ignore-pattern    Ignore a pattern
    --write-file        Write the config file locally
    -h, --help          Displays this message

  Examples
    $ tsdx lint src test
    $ tsdx lint src test --fix
    $ tsdx lint src test --ignore-pattern test/foobar.ts
    $ tsdx lint --write-file

No input files specified.
```