### PR TITLE
Run tests against Node/OS version matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,27 +4,28 @@ on: [push]
 
 jobs:
   test:
-    name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }}
+   
     
     runs-on: ${{ matrix.os }}
     
     strategy:
       matrix:
-        node_version: [8, 10, 12]
+        node: ['8.x', '10.x', '12.x']
         os: [ubuntu-latest, windows-latest, macOS-latest]
-
+    
+    name: Test on node ${{ matrix.node }} and ${{ matrix.os }}
+    
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node_version }}
+      - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
-          version: ${{ matrix.node_version }}
+          node-version: ${{ matrix.node }}
           
-      - name: Install yarn  
+      - name: Install yarn package manager
         run: npm install -g yarn
         
-      - name: Install deps
-        run: yarn install  --frozen-lockfile
-      
-      - name: Test package
-        run: yarn test --runInBand --coverage
+      - name: Install deps and test
+        run: |
+          yarn install --frozen-lockfile
+          yarn test --runInBand     

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,20 +3,28 @@ name: Node CI
 on: [push]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  test:
+    name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }}
+    
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      matrix:
+        node_version: [8, 10, 12]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@master
-    - name: Use Node.js 10.x
-      uses: actions/setup-node@v1
-      with:
-        version: 10.x
-    - name: install yarn  
-      run: npm install -g yarn
-    - name: yarn install, build, and test
-      run: |
-        yarn install  --frozen-lockfile
-        yarn build
-        yarn test
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v1
+        with:
+          version: ${{ matrix.node_version }}
+          
+      - name: Install yarn  
+        run: npm install -g yarn
+        
+      - name: Install deps
+        run: yarn install  --frozen-lockfile
+      
+      - name: Test package
+        run: yarn test --runInBand --coverage

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Install yarn package manager
         run: npm install -g yarn
         
-      - name: Install deps and test
-        run: |
-          yarn install --frozen-lockfile
-          yarn test --runInBand     
+      - name: Install deps and build
+        run: yarn install --frozen-lockfile
+        
+      - name: Test package
+        run: yarn test --runInBand        

--- a/test/jest.config.json
+++ b/test/jest.config.json
@@ -4,5 +4,8 @@
   "transform": {
     "^.+\\.ts?$": "ts-jest"
   },
-  "testMatch": ["<rootDir>/tests/**/?(*.)(spec|test).(ts|js)?(x)"]
+  "testMatch": [
+    "<rootDir>/tests/**/__tests__/**/*.[jt]s?(x)",
+    "<rootDir>/tests/**/*(*.)@(spec|test).[tj]s?(x)"
+  ]
 }


### PR DESCRIPTION
Based on some conversations at React Native EU, tsdx is gaining some users inside of Microsoft. To better support them, this PR updates our GitHub Actions to run the test suite on Node 8, 10, 12 in macOS, windows, and ubuntu.