### PR TITLE
[Deploy Playground] Fix Netlify build command

### DIFF
--- a/templates/react/README.md
+++ b/templates/react/README.md
@@ -128,7 +128,7 @@ Alternatively, if you already have a git repo connected, you can set up continuo
 
 ```bash
 netlify init
-# build command: yarn && yarn build && cd example && yarn && yarn build
+# build command: yarn build && cd example && yarn && yarn build
 # directory to deploy: example/dist
 # pick yes for netlify.toml
 ```

--- a/templates/react/README.md
+++ b/templates/react/README.md
@@ -128,7 +128,7 @@ Alternatively, if you already have a git repo connected, you can set up continuo
 
 ```bash
 netlify init
-# build command: cd example && yarn && yarn build
+# build command: yarn && yarn build && cd example && yarn && yarn build
 # directory to deploy: example/dist
 # pick yes for netlify.toml
 ```


### PR DESCRIPTION
Lib needs to be built to `dist` before example can be built ("Cannot resolve dependency '../../dist'")